### PR TITLE
Byttet til team namespaces

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: syfosmjob
-  namespace: syfosm
+  namespace: teamsykefravr
   labels:
     team: teamsykefravr
 spec:

--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -62,33 +62,37 @@ spec:
                 value: "http://nais-prometheus-prometheus-pushgateway.nais:9091"
             volumeMounts:
               - mountPath: /etc/ssl/certs/ca-certificates.crt
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/tls/certs/ca-bundle.crt
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/ssl/ca-bundle.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/tls/cacert.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/ssl/certs/java/cacerts
-                name: ca-bundle
+                name: ca-bundle-jks
                 subPath: ca-bundle.jks
               - mountPath: /var/run/secrets/nais.io/vault
                 name: vault-volume
                 subPath: subpath/var/run/secrets/nais.io/vault
-          serviceAccount: podcreator
-          serviceAccountName: podcreator
+          serviceAccount: default
+          serviceAccountName: default
           volumes:
             - configMap:
                 defaultMode: 420
-                name: ca-bundle
-              name: ca-bundle
+                name: ca-bundle-pem
+              name: ca-bundle-pem
+            - configMap:
+                defaultMode: 420
+                name: ca-bundle-jks
+              name: ca-bundle-jks
             - emptyDir:
                 medium: Memory
               name: vault-volume

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: syfosmjob
-  namespace: syfosm
+  namespace: teamsykefravr
   labels:
     team: teamsykefravr
 spec:

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -62,22 +62,22 @@ spec:
                 value: "http://nais-prometheus-prometheus-pushgateway.nais:9091"
             volumeMounts:
               - mountPath: /etc/ssl/certs/ca-certificates.crt
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/tls/certs/ca-bundle.crt
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/ssl/ca-bundle.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/tls/cacert.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-                name: ca-bundle
+                name: ca-bundle-pem
                 subPath: ca-bundle.pem
               - mountPath: /etc/ssl/certs/java/cacerts
-                name: ca-bundle
+                name: ca-bundle-jks
                 subPath: ca-bundle.jks
               - mountPath: /var/run/secrets/nais.io/vault
                 name: vault-volume
@@ -87,8 +87,12 @@ spec:
           volumes:
             - configMap:
                 defaultMode: 420
-                name: ca-bundle
-              name: ca-bundle
+                name: ca-bundle-pem
+              name: ca-bundle-pem
+            - configMap:
+                defaultMode: 420
+                name: ca-bundle-jks
+              name: ca-bundle-jks
             - emptyDir:
                 medium: Memory
               name: vault-volume


### PR DESCRIPTION
vi har lansert noe som heter team namespaces, som betyr at man ikke trenger egne namespaces for cronjobs/jobs. Jeg driver i den sammenhengen å faser ut de gamle naisjobs-namespaces. Eneste forskjellen er navnet på namespacet (og at man har flere muligheter i team namespaces).